### PR TITLE
Corrige deploy do ambiente local

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:stable
 RUN apt update && apt install php-fpm php-pgsql \
-	php-mbstring php-curl php7.3-mysql nginx sendmail -y
+	php-mbstring php-curl php7.4-mysql nginx sendmail -y
 COPY transforma.conf /etc/nginx/conf.d/
-COPY  www.conf /etc/php/7.3/fpm/pool.d/
+COPY  www.conf /etc/php/7.4/fpm/pool.d/
 COPY run.sh /tmp
 RUN chmod +x /tmp/run.sh
 COPY . /transforma-minas/

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ restore:
 	docker exec transforma_minas_db_1 /bin/bash -c 'mysql transforma < /tmp/transforma.sql --password=root'
 
 sampleusers:
-	docker cp db/popula-usuarios.sql  transforma-minas_db_1:/tmp
-	docker exec transforma-minas_db_1 /bin/bash -c 'mysql transforma < /tmp/popula-usuarios.sql --password=root'
+	docker cp db/popula-usuarios.sql  transforma_minas_db_1:/tmp
+	docker exec transforma_minas_db_1 /bin/bash -c 'mysql transforma < /tmp/popula-usuarios.sql --password=root'
 
 sampledevdata:
-	docker cp db/transforma-devdata.sql  transforma-minas_db_1:/tmp
-	docker exec transforma-minas_db_1 /bin/bash -c 'mysql transforma < /tmp/transforma-devdata.sql --password=root'
+	docker cp db/transforma-devdata.sql  transforma_minas_db_1:/tmp
+	docker exec transforma_minas_db_1 /bin/bash -c 'mysql transforma < /tmp/transforma-devdata.sql --password=root'

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ up:
 run: build up
 
 restore:
-	docker cp db/transforma.sql  transforma-minas_db_1:/tmp
-	docker exec transforma-minas_db_1 /bin/bash -c 'mysql transforma < /tmp/transforma.sql --password=root'
+	docker cp db/transforma.sql  transforma_minas_db_1:/tmp
+	docker exec transforma_minas_db_1 /bin/bash -c 'mysql transforma < /tmp/transforma.sql --password=root'
 
 sampleusers:
 	docker cp db/popula-usuarios.sql  transforma-minas_db_1:/tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,11 @@ services:
     env_file:
       - .env
     entrypoint: /tmp/run.sh
-    #entrypoint: tail -f /dev/null
+    environment:
+      - DB_HOST=transforma_minas_db_1
+      - DB_DATABASE=transforma
+      - DB_PASSWORD=root
+      - DB_USERNAME=root
   db:
     image: mariadb:10.3
     volumes:

--- a/run.sh
+++ b/run.sh
@@ -4,10 +4,10 @@ mkdir -p application/logs
 chown www-data:www-data application/logs
 
 # https://serverfault.com/questions/813368/configure-php-fpm-to-access-environment-variables-in-docker
-sed -i "s#;clear_env = no#clear_env = no#" /etc/php/7.3/fpm/pool.d/www.conf
+sed -i "s#;clear_env = no#clear_env = no#" /etc/php/7.4/fpm/pool.d/www.conf
 
 # php service
-/etc/init.d/php7.3-fpm start
+/etc/init.d/php7.4-fpm start
 
 #keep the container running
 nginx -g 'daemon off;'

--- a/transforma.conf
+++ b/transforma.conf
@@ -17,6 +17,7 @@ server {
         include snippets/fastcgi-php.conf;
 
         # With php-fpm:
+        # TODO: por algum motivo o php 7.4 cria o socket com o nome php7.3, apesar dele não existir no container.
         fastcgi_pass unix:/run/php/php7.3-fpm.sock;
         # With php-cgi:
         # fastcgi_pass 127.0.0.1:9000;


### PR DESCRIPTION
  - O debian lançou uma nova versão stable, que alterou a versão do php.
    Isso estava fazendo o comando `make run` quebrar.
  - closes #2